### PR TITLE
feat: enable client rendering for Instagram likes page

### DIFF
--- a/src/app/(services)/buy-instagram-likes/page.tsx
+++ b/src/app/(services)/buy-instagram-likes/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export const metadata = {{ title: "Buy Instagram Likes — Likes.io" }};
 
 export default function Page() {{


### PR DESCRIPTION
## Summary
- enable client-side rendering on Instagram likes page by adding `"use client"`

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_6896b7837f4c83328106bd128f3601df